### PR TITLE
Set apt defaults as role vars with defaults from apt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Set up netplan in Debian-like systems.
 #### Variables
 
 * `netplan_install` [default: `[]`]: Additional packages to install
+* `netplan_pkgs_install_state` [default: `present`]: State of the netplan packages regarding the apt module `absent | build-dep | latest | present | fixed`
+* `netplan_apt_update_cache_valid_time` [default: `0`]: Adjust the apt cache expiration time as per the apt module, default is `0` no expiration
 
 * `netplan_version` [default: `2`]: Version
 * `netplan_renderer` [default: `networkd`]: Renderer

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 # defaults file
 ---
 netplan_install: []
+netplan_pkgs_install_state: "present"
+netplan_apt_update_cache_valid_time: "0"
 
 netplan_version: 2
 netplan_renderer: networkd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,15 +3,15 @@
 - name: install | dependencies
   ansible.builtin.apt:
     name: "{{ netplan_dependencies }}"
-    state: "{{ apt_install_state | default('latest') }}"
+    state: "{{ netplan_pkgs_install_state | default('present') }}"
     update_cache: true
-    cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
+    cache_valid_time: "{{ netplan_apt_update_cache_valid_time | default(0) }}"
   tags:
     - netplan-install-dependencies
 
 - name: install | additional
   ansible.builtin.apt:
     name: "{{ netplan_install }}"
-    state: "{{ apt_install_state | default('latest') }}"
+    state: "{{ netplan_pkgs_install_state | default('present') }}"
   tags:
     - netplan-install-additional


### PR DESCRIPTION
The Netplan role was using `latest` instead of `present` for the Netplan related packages which are not the defaults from the `apt` module, I think it is better to be on the safe side and not update by default unless users explicitly ask for it?

I have renamed the variables too so that they can be used without collisions and use the convention`<rolename>_varname` 

- `netplan_pkgs_install_state`
- `netplan_apt_update_cache_valid_time`
